### PR TITLE
Update maximum for D&D system to 3.1.0

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
         "compatibility": {
           "minimum": "2",
           "verified": "2.4",
-          "maximum": "3"
+          "maximum": "3.1.0"
         }
       }
     ],

--- a/module.json
+++ b/module.json
@@ -14,9 +14,9 @@
         "id": "dnd5e",
         "type": "system",
         "compatibility": {
-          "minimum": "2",
-          "verified": "2.4",
-          "maximum": "3.1.0"
+          "minimum": "3",
+          "verified": "3.0.0",
+          "maximum": "4"
         }
       }
     ],


### PR DESCRIPTION
While there might be translations missing, users upgrading to DnD 3.0.0 are surprised to find the whole module is out.

The original code set the maximum to "3", which should be equivalent to "3.0.0", but for some reason, isn't, so I guess this is ok to support "3.0.0"

I propose to let the maximum to be 3.1.0, because I guess there might be surprise patches to DnD3.0.0 (like, 3.0.1, 3.0.2) cause by minor bugs that escaped delivery.