### PR TITLE
Update fr.json - Fix typo

### DIFF
--- a/fr.json
+++ b/fr.json
@@ -2044,8 +2044,8 @@
   "SETTINGS": {
     "5eAllowPolymorphingL": "Permettre aux acteurs de transformer (polymorphisme) leurs propres acteurs.",
     "5eAllowPolymorphingN": "Permettre le polymorphisme",
-    "5eAutoCollapseCardL": "Réduire automatiquement les descriptions de la carte d'item dans le journal de Chat",
-    "5eAutoCollapseCardN": "Réduire les cartes d'items dans le Chat",
+    "5eAutoCollapseCardL": "Réduire automatiquement les descriptions de la carte d'item dans le journal de tchat",
+    "5eAutoCollapseCardN": "Réduire les cartes d'items dans le tchat",
     "5eAutoSpellTemplateL": "Lorsqu'un sort est lancé, commence par créer le gabarit correspondant le cas échéant (nécessite un role de joueur de 'confiance' -TRUSTED- ou supérieur)",
     "5eAutoSpellTemplateN": "Toujours poser le gabarit du sort",
     "5eChallengeVisibility": {
@@ -2113,8 +2113,8 @@
       },
       "COLLAPSETRAYS": {
         "Always": "Tout réduire",
-        "Hint": "Réduire automatiquement les sections de dégâts, de touches et d'effets qui apparaissent dans les cartes de chat.",
-        "Name": "Réduire les sections dans le chat",
+        "Hint": "Réduire automatiquement les sections de dégâts, de touches et d'effets qui apparaissent dans les cartes de tchat.",
+        "Name": "Réduire les sections dans le tchat",
         "Never": "Tout développer",
         "Older": "Réduire les sections plus anciennes"
       },


### PR DESCRIPTION
Typo sur "chat" et "tchat" dire d'être raccord avec le lexique de la traduction du core.