### PR TITLE
Correction de l'écrasement de l'identifier

### DIFF
--- a/babele-register.js
+++ b/babele-register.js
@@ -424,7 +424,10 @@ export class Converters {
 			if (translation) {
 				return foundry.utils.mergeObject(adv, {
 					title: translation.title ?? adv.title,
-					hint: translation.hint ?? adv.hint
+					hint: translation.hint ?? adv.hint,
+					configuration: {
+						identifier: adv.configuration.identifier?.length > 0 ? adv.configuration.identifier : adv.title?.slugify()
+					}
 				});
 			}
 			return adv;


### PR DESCRIPTION
Lors de la traduction du titre d'une progression de type Scale Value, si la progression n'avait pas d'identifier, celui-ci était écrasé par le titre traduit en slugify().