### PR TITLE
Translations update from Fonderie VTT - Weblate

### DIFF
--- a/compendium_fr/dnd5e.monsterfeatures.json
+++ b/compendium_fr/dnd5e.monsterfeatures.json
@@ -663,95 +663,95 @@
       "description": "<section class=\"secret\"><p>Si une créature commence son tour dans un rayon de 9 m du [[lookup @name lowercase]] et que les deux se voient mutuellement, le [[lookup @name lowercase]] peut contraindre la créature à effectuer un jet de sauvegarde de Constitution DD 12 s'il n’est pas neutralisé. En cas d'échec, la créature est entravée et commence à se transformer magiquement en pierre. Elle doit réitérer le jet de sauvegarde à la fin de son tour suivant. En cas de réussite, l'effet prend fin. En cas d'échec, la créature est pétrifiée jusqu'à ce que le sort restauration suprême ou une magie comparable la libère.</p><p>Toute créature qui n'est pas surprise peut détourner le regard au début de son tour pour se soustraire au jet de sauvegarde. Ce faisant, la créature ne voit pas le [[lookup @name lowercase]] jusqu'au début de son tour suivant, moment auquel elle peut de nouveau détourner les yeux. Si la créature regarde le [[lookup @name lowercase]] entretemps, elle doit aussitôt effectuer le JS.</p><p>Si le [[lookup @name lowercase]] voit son reflet dans un rayon de 9 m et sous une lumière vive, il le prend pour un rival et se cible lui-même avec son regard.</p></section><p>Le [[lookup @name lowercase]] peut contraindre la créature à effectuer un jet de sauvegarde de <strong>Constitution</strong>. Elle doit réitérer le jet de sauvegarde à la fin de son tour suivant. Toute créature qui n'est pas surprise peut détourner le regard au début de son tour pour se soustraire au jet de sauvegarde. Ce faisant, la créature ne voit pas le [[lookup @name lowercase]] jusqu'au début de son tour suivant, moment auquel elle peut de nouveau détourner les yeux. Si la créature regarde le [[lookup @name lowercase]] entretemps, elle doit aussitôt effectuer le JS.</p>"
     },
     "Phantasms": {
-      "name": "Fantasmes",
-      "description": "<p>(Recharge après un repos court ou long). Le manteleur crée magiquement trois copies illusoires de lui-même s'il n'est pas dans une zone de lumière vive. Les copies se déplacent avec lui et imitent ses actions, modifiant leurs positions de sorte que chaque copie paraisse être le véritable manteleur. Si le manteleur pénètre une zone de lumière vive, les copies disparaissent. À chaque fois qu'une créature cible le manteleur avec une attaque ou un sort nuisible alors qu'il reste des copies, la créature fait un jet aléatoire pour déterminer si elle cible le manteleur ou l'une de ses copies. Une créature n'est pas affectée par cet effet si elle ne peut pas voir ou si elle se sert d'un autre sens que la vue. Une copie a la même CA que le manteleur et utilise ses modificateurs de sauvegarde. Si une attaque touche une copie, ou si une copie échoue son jet de sauvegarde contre un effet qui inflige des dégâts, la copie disparaît.</p>"
+      "name": "Fantasmagories",
+      "description": "<p>S'il n’est pas exposé à une lumière vive, le [[lookup @name lowercase]] crée magiquement trois doubles illusoires de lui-même. Ces doubles se déplacent avec lui, reproduisent ses actions et échangent mutuellement de position, si bien qu'il est impossible de savoir où est le vrai [[lookup @name lowercase]]. Si le [[lookup @name lowercase]] se retrouve dans une zone de lumière vive, les doubles disparaissent.</p><p>Chaque fois qu'une créature cible le [[lookup @name lowercase]] avec une attaque ou un sort nuisible alors qu'il reste au moins un double, on détermine au hasard si l'attaque cible le [[lookup @name lowercase]] ou l'un de ses doubles. Une créature qui ne voit rien ou se fie à d'autres sens que la vision n'est pas affectée par cet effet magique.</p><p>Chaque double reprend la CA du [[lookup @name lowercase]] et ses jets de sauvegarde. Si une attaque touche un double ou si un double rate un jet de sauvegarde contre un effet qui inflige des dégâts, le double disparaît.</p>"
     },
     "Poison Breath": {
       "name": "Souffle empoisonné",
-      "description": "<p>(Recharge 5-6). La créature exhale un nuage de gaz empoisonné dans un cône de 9 mètres. Toutes les créatures dans la zone doivent réaliser un jet de sauvegarde de Constitution DD 14, subissant 42 (12d6) dégâts de poison si le jet de sauvegarde est raté, ou la moitié de ces dégâts en cas de réussite.</p>"
+      "description": "<section class=\"secret\"><p>Le [[lookup @details.type.config.label lowercase]] crache des vapeurs toxiques sous forme d'un cône de 18 m. Chaque créature prise dans la zone effectue un jet de sauvegarde de Constitution DD 18 et subit 56 (16d6) dégâts de poison en cas d'échec, la moitié en cas de réussite.</p></section><p>Le [[lookup @details.type.config.label lowercase]] crache des vapeurs toxiques sous forme d'un cône de 18 m. Chaque créature prise dans la zone effectue un jet de sauvegarde de <strong>Constitution</strong>.</p>"
     },
     "Possession": {
-      "name": "Possession ",
-      "description": "<p>(Recharge 6). Un humanoïde que le fantôme peut voir et se trouvant à 1,50 mètre de lui doit réussir un jet de sauvegarde de Charisme DD 13 ou être possédé par le fantôme ; le fantôme disparait alors, et la cible est incapable d'agir et perd le contrôle de son corps. Le fantôme contrôle désormais le corps de la cible, mais ne prive pas la cible de sa conscience. Le fantôme ne peut être pris pour cible par aucune attaque, sort, ou autres effets, à part ceux qui repoussent les morts-vivants, et il conserve son alignement, ses valeurs d'Intelligence, de Sagesse et de Charisme, ainsi que son immunité aux effets charmé et effrayé. Pour le reste, il utilise les statistiques de la cible, mais sans avoir accès à ses connaissances, capacités de classe et maîtrises. La possession dure jusqu'à ce que la cible tombe à 0 point de vie, que le fantôme l'annule par une action bonus, ou que le fantôme soit repoussé ou renvoyé de force par un effet similaire au sort de dissipation du mal et du bien. Lorsque la possession se termine, le fantôme réapparaît dans un espace inoccupé situé à 1,50 mètre du corps. Une cible est immunisée à la possession du fantôme pendant 24 heures si elle réussit son jet de sauvegarde ou si la possession se termine."
+      "name": "Possession",
+      "description": "<section class=\"secret\"><p>Un humanoïde que le [[lookup @name lowercase]] voit dans un rayon de 1,50 m doit réussir un jet de sauvegarde de Charisme DD 13 sous peine d'être possédé par le [[lookup @name lowercase]] ; ce dernier disparaît alors et la cible, neutralisée, perd le contrôle de son corps. C'est désormais le [[lookup @name lowercase]] qui en a le contrôle, mais la cible reste consciente. Les attaques, sorts et autres effets ne peuvent pas cibler le [[lookup @name lowercase]], en dehors de ceux qui renvoient les [[lookup @details.type.config.label lowercase]]. Il conserve son alignement, ses valeurs d'Intelligence, de Sagesse et de Charisme, et son immunité contre les états charmé et effrayé. Pour le reste, il reprend le profil de jeu de la cible possédée mais n'a accès ni à son savoir, ni à ses aptitudes de classe, ni à ses maîtrises.</p><p>La possession persiste jusqu'à ce que le corps tombe à 0 point de vie, que le [[lookup @name lowercase]] y mette un terme par une action bonus ou qu'il soit renvoyé (ou encore chassé du corps par un effet tel que dissipation du mal et du bien). Quand la possession prend fin, le [[lookup @name lowercase]] réapparaît en un espace inoccupé dans un rayon de 1,50 m du corps. Si elle réussit le jet de sauvegarde ou quand la possession prend fin, la cible devient immunisée contre la possession de ce [[lookup @name lowercase]] pendant 24 heures.</p></section><p>Un humanoïde que le [[lookup @name lowercase]] voit dans un rayon de 1,50 m doit effectuer un jet de sauvegarde de <strong>Charisme</strong>.</p>"
     },
     "Pounce": {
-      "name": "Bond",
-      "description": "<p>Si la créature se déplace d'au moins 6 mètres en ligne droite vers une créature, puis la touche lors d'une attaque avec ses griffes dans le même tour, la cible doit réussir un jet de sauvegarde de Force DD 13 pour ne pas tomber à terre. Si la cible est à terre, le lion peut effectuer une attaque de morsure contre elle en tant qu'action bonus.</p>"
+      "name": "Bond agressif",
+      "description": "<section class=\"secret\"><p>Si le [[lookup @name lowercase]] se déplace d'au moins 6 m en ligne droite vers une créature qu'il touche ensuite avec une attaque de Griffe au même tour, la cible doit réussir un jet de sauvegarde de Force DD 13 sous peine d'être jetée à terre. Si la cible est à terre, le [[lookup @name lowercase]] peut effectuer contre elle une attaque de Morsure par une action bonus.</p></section><p>Si le [[lookup @name lowercase]] se déplace d'au moins <strong>6 m</strong> en ligne droite vers une créature qu'il touche ensuite avec une attaque de Griffe au même tour, la cible doit effectuer un jet de sauvegarde de <strong>Force</strong>.</p>"
     },
     "Probing Telepathy": {
-      "name": "Pénétration télépathique",
-      "description": "Si une créature communique par télépathie avec l'aboleth, l'aboleth découvre les plus grands désirs de la créature, à condition qu'il puisse voir la créature."
+      "name": "Télépathie inquisitrice",
+      "description": "<p>Si une créature communique par télépathie avec l'[[lookup @name lowercase]], ce dernier a conscience des désirs profonds de la créature à condition de la voir.</p>"
     },
     "Psychic Drain": {
-      "name": "Absorption psychique",
-      "description": "(coûte 2 actions). Une créature charmée par l'aboleth subit 10 (3d6) dégâts psychiques, et l'aboleth récupère un montant de point de vie égal aux dégâts que cette créature a subis."
+      "name": "Succion psychique",
+      "description": "<p>Une créature charmée par l'[[lookup @name lowercase]] subit 10 (3d6) dégâts psychiques, et l'[[lookup @name lowercase]] récupère autant de points de vie que la créature subit de dégâts.</p>"
     },
     "Rampage": {
       "name": "Déchaînement",
-      "description": "<p>Lorsque durant son tour la créature fait tomber les points de vie d'une créature à 0 avec une attaque au corps à corps, elle peut utiliser une action bonus pour se déplacer de la moitié de sa vitesse et effectuer une attaque de morsure.</p>"
+      "description": "<p>Après que le [[lookup @name lowercase]] a fait tomber une créature à 0 point de vie avec une attaque de corps à corps à son tour, il peut entreprendre une action bonus pour se déplacer à concurrence de la moitié de sa vitesse et effectuer une attaque de Morsure.</p>"
     },
     "Reactive": {
-      "name": "Réaction",
-      "description": "La {créature} peut faire une réaction à chaque tour de combat."
+      "name": "Réactivité",
+      "description": "<p>La [[lookup @name lowercase]] peut jouer une réaction à chaque tour d'un combat.</p>"
     },
     "Reactive Heads": {
-      "name": "Reactive Heads",
-      "description": "<p>For each head the hydra has beyond one, it gets an extra reaction that can be used only for opportunity attacks.</p>"
+      "name": "Têtes réactives",
+      "description": "<p>Chaque tête dont est dotée l'[[lookup @name lowercase]] au-delà de la première lui octroie une réaction supplémentaire qu'elle ne peut jouer que pour effectuer une attaque d'opportunité.</p>"
     },
     "Read Thoughts": {
       "name": "Lecture des pensées",
-      "description": "<p>Le doppelganger lit par magie les pensées de surface d'une créature située à 18 mètres ou moins de lui. Cet effet peut passer au travers d'un obstacle, mais est bloqué par 90 centimètres de bois ou de terre, 60 centimètres de pierre, 5 centimètres de métal ou une fine couche de plomb. Quand la cible est à portée, le doppelganger peut lire ses pensées tant que sa concentration n'est pas rompue (de la même manière que la concentration pour un sort). Le doppelganger a un avantage aux jets de Sagesse (Perspicacité) et de Charisme (Intimidation, Persuasion et Tromperie) contre une cible dont il lit les pensées.</p>"
+      "description": "<section class=\"secret\"><p>Le [[lookup @name lowercase]] lit magiquement les pensées superficielles d'une créature située dans un rayon de 18 m. L'effet perce la plupart des obstacles mais 90 cm de bois ou de terre, 60 cm de pierre, 5 cm de métal (ou une simple feuille dans le cas du plomb) suffisent à le bloquer. Tant que la cible reste à portée, le [[lookup @name lowercase]] peut continuer à lire ses pensées, à condition que sa concentration ne soit pas rompue (comme pour un sort). Tant qu'il sonde l'esprit de la cible, le [[lookup @name lowercase]] est avantagé à ses tests de Sagesse (Intuition) et Charisme (Intimidation, Persuasion et Tromperie) contre la cible.</p></section><p>Le [[lookup @name lowercase]] lit magiquement les pensées superficielles d'une créature située dans un rayon de 18 m.</p>"
     },
     "Reaping Scythe": {
-      "name": "Faux moissonneuse",
-      "description": " L'avatar balaye de sa faux une créature située à 1,50 mètre de lui, infligeant 7 (1d8 + 3) dégâts tranchants + 4 (1d8) dégâts nécrotiques."
+      "name": "Faux tournoyante",
+      "description": "<section class=\"secret\"><p>L'[[lookup @name lowercase]] abat sa faux spectrale sur une créature située dans un rayon de 1,50 m de lui, et lui inflige 7 (1d8 + 3) dégâts tranchants plus 4 (1d8) dégâts nécrotiques.</p></section><p>L'[[lookup @name lowercase]] abat sa faux spectrale sur une créature située dans un rayon de 1,50 m de lui.</p>"
     },
     "Reckless": {
       "name": "Téméraire",
-      "description": "<p>Au début de son tour, le minotaure peut obtenir un avantage à tous les jets d'attaque au corps à corps avec une arme pendant ce tour, mais les attaques contre lui ont un avantage jusqu'au début de son prochain tour.</p>"
+      "description": "<p>Au début de son tour, le [[lookup @name lowercase]] peut s'octroyer l'avantage à tous ses jets d'attaque d'arme de corps à corps du tour, auquel cas tous les jets d'attaque contre lui sont avantagés jusqu'au début de son tour suivant.</p>"
     },
     "Reel": {
-      "name": "Embobiner",
-      "description": "<p>L'enlaceur tire à lui sur 7,50 mètres chaque créature qu'il a agrippée.</p>"
+      "name": "Traction",
+      "description": "<p>L'[[lookup @name lowercase]] tire vers lui chaque créature agrippée, en ligne droite, d'un maximum de 7,50 m.</p>"
     },
     "Reflective Carapace": {
       "name": "Carapace réfléchissante",
-      "description": "Chaque fois que la {creature} est ciblée par un sort de projectile magique, un sort dont la zone d'effet est une ligne, ou un sort requérant un jet d'attaque à distance, lancez un d6. De 1 à 5, la {creature} n'est pas affectée. Sur un 6, la {creature} n'est pas affectée, et l'effet est renvoyé vers le lanceur de sorts comme s'il provenait de la {creature}, le lanceur devenant donc la cible."
+      "description": "<section class=\"secret\"><p>Chaque fois que la [[lookup @name lowercase]] est ciblée par le sort projectile magique, un sort de ligne ou un sort qui nécessite un jet d'attaque à distance, lancez un d6. Sur un résultat de 1 à 5, la [[lookup @name lowercase]] n'est pas affectée. Sur un 6, la [[lookup @name lowercase]] n'est pas affectée et l'effet est renvoyé vers l'incantateur, comme s'il émanait de la [[lookup @name lowercase]], si bien que le lanceur du sort en devient la cible.</p></section><p>La [[lookup @name lowercase]] n'est pas affectée et l'effet est renvoyé vers l'incantateur, comme s'il émanait de la [[lookup @name lowercase]], si bien que le lanceur du sort en devient la cible.</p>"
     },
     "Regeneration": {
       "name": "Régénération",
-      "description": "<p>La créature récupère 10 points de vie au début de son tour s'il possède au moins 1 point de vie.</p>"
+      "description": "<section class=\"secret\"><p>Le [[lookup @name lowercase]] récupère 10 points de vie au début de son tour s'il lui reste au moins 1 point de vie.</p></section><p>Le [[lookup @name lowercase]] récupère <strong>10 points de vie</strong> au début de son tour.</p>"
     },
     "Regional Effects": {
       "name": "Effets régionaux",
-      "description": "La simple présence d'une créature légendaire peut avoir des effets étranges et merveilleux sur son environnement. Les effets régionaux se terminent brusquement ou se dissipent avec le temps lorsque la créature légendaire meurt."
+      "description": "<p>La seule présence d'une créature légendaire peut engendrer d'étranges et merveilleux effets sur l'environnement. Certains effets régionaux prennent subitement fin, d'autres se dissipent progressivement quand la créature légendaire meurt.</p>"
     },
     "Rejuvenation": {
       "name": "Reconstitution",
-      "description": "S'il meurt, le {creature} revient à la vie en 1d6 jours et retrouve tous ses points de vie. Seul un sort de souhait peut empêcher ce trait de fonctionner."
+      "description": "<section class=\"secret\"><p>S'il meurt, le [[lookup @name lowercase]] revient à la vie en 1d6 jours et récupère tous ses points de vie. Seul le sort souhait peut empêcher ce trait de fonctionner.</p></section><p>S'il meurt, le [[lookup @name lowercase]] revient à la vie en 1d6 jours et récupère tous ses <strong>points de vie</strong>.</p>"
     },
     "Relentless": {
       "name": "Implacable",
-      "description": "<p>(Recharge après un Repos court ou long). Si le sanglier subit 10 points de dégâts ou moins qui réduiraient ses points de vie à 0, il se retrouve à la place avec 1 point de vie.</p>"
+      "description": "<section class=\"secret\"><p>Si le [[lookup @name lowercase]] subit 7 dégâts ou moins censés le faire tomber à 0 point de vie, il se retrouve en fait à 1 point de vie. Recharge après un repos court ou long.</p></section><p>Si le [[lookup @name lowercase]] subit des dégâts censés le faire tomber à <strong>0 point de vie</strong>, il se retrouve en fait à <strong>1 point de vie</strong>.</p>"
     },
     "Repulsion Breath": {
       "name": "Souffle répulsif",
-      "description": "<p>Le dragon crache une énergie répulsive dans un cône de 9 mètres. Chaque créature dans cette zone doit effectuer un jet de sauvegarde de Force DD 12. En cas d'échec, la créature est repoussée du dragon sur 12 mètres.</p>"
+      "description": "<section class=\"secret\"><p>**Souffle répulsif.** Le [[lookup @details.type.config.label lowercase]] exhale des énergies répulsives sous forme d'un cône de 9 m. Chaque créature prise dans la zone effectue un jet de sauvegarde de Force DD 19. En cas d'échec, la créature est repoussée de 18 m du [[lookup @details.type.config.label lowercase]].</p></section><p>Le [[lookup @details.type.config.label lowercase]] exhale des énergies répulsives sous forme d'un cône de 9 m. Chaque créature prise dans la zone effectue un jet de sauvegarde de <strong>Force</strong>.</p>"
     },
     "Roar": {
       "name": "Rugissement",
-      "description": "Le {creature} pousse un rugissement magique. Chaque fois qu'il rugit avant d'avoir terminé un repos long, le rugissement est de plus en plus fort et son effet différent, comme détaillé ci-dessous. Chaque créature se trouvant à 150 mètres du {creature} et étant capable de l'entendre doivent réaliser un jet de sauvegarde."
+      "description": "<section class=\"secret\"><p>Le [[lookup @name lowercase]] pousse un rugissement magique. Chaque fois qu'il rugit avant de terminer un repos long, son cri se fait plus puissant et l'effet diffère, comme détaillé ci-après. Chaque créature située dans un rayon de 150 m du [[lookup @name lowercase]] effectue un jet de sauvegarde si elle l'entend.</p><p>**Premier rugissement.** Toute créature qui rate un jet de sauvegarde de Sagesse DD 18 est effrayée pendant 1 minute. Une créature effrayée peut réitérer le jet de sauvegarde à la fin de chacun de ses tours et met un terme à l'effet sur elle-même en cas de réussite.</p><p>**Deuxième rugissement.** Toute créature qui rate un jet de sauvegarde de Sagesse DD 18 est assourdie et effrayée pendant 1 minute. Une créature ainsi effrayée est paralysée, et peut réitérer le jet de sauvegarde à la fin de chacun de ses tours ; elle met un terme à l'effet sur elle-même en cas de réussite.</p><p>**Troisième rugissement.** Chaque créature concernée effectue un jet de sauvegarde de Constitution DD 18. En cas d'échec, elle subit 44 (8d10) dégâts de tonnerre et se retrouve à terre. En cas de réussite, la créature subit la moitié de ces dégâts et n'est pas jetée à terre.</p></section><p>Le [[lookup @name lowercase]] pousse un rugissement magique. Chaque fois qu'il rugit avant de terminer un repos long, son cri se fait plus puissant et l'effet diffère. Chaque créature située dans un rayon de 150 m du [[lookup @name lowercase]] effectue un jet de sauvegarde si elle l'entend.</p>"
     },
     "Rock Catching": {
       "name": "Réception de rocher",
-      "description": "<p>Si un rocher ou un objet similaire est envoyé au géant, le géant peut, s'il réussit un jet de sauvegarde de Dextérité DD 10, attraper le projectile et ainsi en éviter les dégâts contondants.</p>"
+      "description": "<section class=\"secret\"><p>Si on lance un rocher ou un objet comparable sur le [[lookup @details.type.config.label lowercase]], ce dernier peut intercepter le projectile qui ne lui inflige alors aucun dégât contondant, à condition de réussir un jet de sauvegarde de Dextérité DD 10.</p></section><p>Si on lance un rocher ou un objet comparable sur le [[lookup @details.type.config.label lowercase]], ce dernier peut intercepter le projectile qui ne lui inflige alors aucun <em>dégât contondant</em>.</p>"
     },
     "Running Leap": {
-      "name": "Course d'élan",
-      "description": "<p>S'il peut prendre une course d'élan de 3 mètres, une créature peut sauter jusqu'à 7,50 mètres.</p>"
+      "name": "Saut avec élan",
+      "description": "<p>Avec une prise d’élan de 3 m, le [[lookup @name lowercase]] peut franchir jusqu'à 7,50 m d'un saut en longueur.</p>"
     },
     "Rust Metal": {
-      "name": "Oxydation",
+      "name": "Corrosion du métal",
       "description": "<p>Toute arme non magique constituée de métal qui touche l'oxydeur se met à rouiller. Après avoir infligé les dégâts, l'arme subit une pénalité permanente et cumulative de -1 aux jets de dégâts. Si la pénalité arrive à -5, l'arme est détruite. Les munitions non magiques constituées de métal qui touchent l'oxydeur sont détruites après avoir infligé leurs dégâts.</p>"
     },
     "Scare": {


### PR DESCRIPTION
Translations update from [Fonderie VTT - Weblate](https://weblate.fonderievtt.fr) for [DnD5e - Lang FR/Système](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/systeme/).


It also includes following components:

* [DnD5e - Lang FR/items](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/items/)

* [DnD5e - Lang FR/races](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/races/)

* [DnD5e - Lang FR/monsterfeatures](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/monsterfeatures/)

* [DnD5e - Lang FR/spells](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/spells/)

* [DnD5e - Lang FR/tables](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/tables/)

* [DnD5e - Lang FR/classfeatures](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/classfeatures/)

* [DnD5e - Lang FR/classes](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/classes/)

* [DnD5e - Lang FR/tradegoods](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/tradegoods/)

* [DnD5e - Lang FR/heroes](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/heroes/)

* [DnD5e - Lang FR/rules](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/rules/)

* [DnD5e - Lang FR/backgrounds](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/backgrounds/)

* [DnD5e - Lang FR/monsters](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/monsters/)

* [DnD5e - Lang FR/subclasses](https://weblate.fonderievtt.fr/projects/dnd5e-lang-fr/subclasses/)



Current translation status:

![Weblate translation status](https://weblate.fonderievtt.fr/widget/dnd5e-lang-fr/systeme/horizontal-auto.svg)