### PR TITLE
Proposal for migrating to the new features introduced in Babele from ver.2.9.x

### DIFF
--- a/babele-register.js
+++ b/babele-register.js
@@ -1,41 +1,33 @@
-import { Converters as babeleConverters } from "../babele/script/converters.js";
 import { registerCustomEnrichersFr } from "./enrichers-fr.mjs";
 import NPCDataFr from "./npc-embedded-fr.mjs";
 
-Hooks.once('init', () => {
+Hooks.once("babele.init", (babele) => {
+	babele.register({
+		module: "dnd5e_fr-FR",
+		lang: "fr",
+		dir: "compendium_fr"
+	});
 
-	if (typeof Babele !== 'undefined') {
-
-		game.babele.register({
-			module: 'dnd5e_fr-FR',
-			lang: 'fr',
-			dir: 'compendium_fr'
-		});
-
-		game.babele.registerConverters({
-			"items": babeleConverters.fromDefaultMapping("Item", "items"),
-			"grid": Converters.imperialToMetric("grid"),
-			"range": Converters.imperialToMetric("range"),
-			"weight": Converters.imperialToMetric("weight"),
-			"target": Converters.imperialToMetric("target"),
-			"senses": Converters.imperialToMetric("senses"),
-			"volume": Converters.imperialToMetric("volume"),
-			"travel": Converters.imperialToMetric("travel"),
-			"movement": Converters.imperialToMetric("movement"),
-			"tokenLight": Converters.imperialToMetric("tokenLight"),
-			"sightRange": Converters.imperialToMetric("sightRange"),
-			"communication": Converters.imperialToMetric("communication"),
-			"rangeActivities": Converters.imperialToMetric("rangeActivities"),
-			"distanceAdvancement": Converters.imperialToMetric("distanceAdvancement"),
-			"pages": Converters.pages(),
-			"tokens": Converters.tokens(),
-			"effects": Converters.effects(),
-			"alignment": Converters.alignment(),
-			"activities": Converters.activities(),
-			"advancement": Converters.advancement(),
-			"planarSubtype": Converters.planarSubtype()
-		});
-	}
+	babele.registerConverters({
+		"grid": Converters.imperialToMetric("grid"),
+		"range": Converters.imperialToMetric("range"),
+		"weight": Converters.imperialToMetric("weight"),
+		"target": Converters.imperialToMetric("target"),
+		"senses": Converters.imperialToMetric("senses"),
+		"volume": Converters.imperialToMetric("volume"),
+		"travel": Converters.imperialToMetric("travel"),
+		"movement": Converters.imperialToMetric("movement"),
+		"tokenLight": Converters.imperialToMetric("tokenLight"),
+		"sightRange": Converters.imperialToMetric("sightRange"),
+		"communication": Converters.imperialToMetric("communication"),
+		"advancementIdentifier": Converters.advancementIdentifier(),
+		"advancementDistance": Converters.advancementDistance(),
+		"advancementScaleDistance": Converters.advancementScaleDistance(),
+		"effectDistanceChange": Converters.effectDistanceChange(),
+		"effectRangeChange": Converters.effectRangeChange(),
+		"alignment": Converters.alignment(),
+		"planarSubtype": Converters.planarSubtype()
+	});
 });
 
 Hooks.once('ready', () => {
@@ -62,12 +54,12 @@ function convertMetricVolume() {
 export class Converters {
 
 	static imperialToMetric(type) {
-		return (value) => {
+		const converter = (value, translation) => {
 			switch (type) {
 				case "grid": return Converters.grid(value);
-				case "range": return Converters.range(value);
+				case "range": return Converters.range(value, translation);
 				case "weight": return Converters.weight(value);
-				case "target": return Converters.target(value);
+				case "target": return Converters.target(value, translation);
 				case "senses": return Converters.senses(value);
 				case "volume": return Converters.volume(value);
 				case "travel": return Converters.travel(value);
@@ -75,13 +67,19 @@ export class Converters {
 				case "tokenLight": return Converters.tokenLight(value);
 				case "sightRange": return Converters.footsToMeters(value);
 				case "communication": return Converters.communication(value);
-				case "rangeActivities": return Converters.rangeActivities(value);
-				case "distanceAdvancement": return Converters.distanceAdvancement(value);
 				default:
 					console.warn(`Type: '${type}' not implemented !`);
 					break;
 			}
 		};
+
+		converter.extract = (value, _source, _tc, context = {}) => {
+			if (type === "range" && context.path === "range") return value?.special;
+			if (type === "target" && context.path === "target") return value?.affects?.special;
+			return undefined;
+		};
+
+		return converter;
 	}
 
 	static get conversionInfo() {
@@ -110,15 +108,20 @@ export class Converters {
 		});
 	}
 
-	static range(range) {
+	static range(range, translation) {
+		const converted = {};
 		const conversion = Converters.conversionInfo[range.units];
-		if (!conversion) return range;
-		return foundry.utils.mergeObject(range, {
-			"value": conversion.converter(range.value),
-			"long": conversion.converter(range.long),
-			"reach": conversion.converter(range.reach),
-			"units": conversion.units
-		});
+		if (convertMetricLength() && conversion) {
+			foundry.utils.mergeObject(converted, {
+				"value": conversion.converter(range.value),
+				"long": conversion.converter(range.long),
+				"reach": conversion.converter(range.reach),
+				"units": conversion.units
+			});
+		}
+
+		Converters.applyScalarOrObjectTranslation(converted, "special", translation);
+		return Object.keys(converted).length ? converted : undefined;
 	}
 
 	static weight(weight) {
@@ -128,20 +131,25 @@ export class Converters {
 		});
 	}
 
-	static target(target) {
+	static target(target, translation) {
+		const converted = {};
 		const conversion = Converters.conversionInfo[target.template?.units];
-		if (!conversion) return target;
-		return foundry.utils.mergeObject(target, {
-			template: {
-				"size": conversion.converter(target.template.size),
-				"height": conversion.converter(target.template.height),
-				"width": conversion.converter(target.template.width),
-				"units": conversion.units
-			},
-			affects: {
-				"count": conversion.converter(target.affects.count)
-			}
-		});
+		if (convertMetricLength() && conversion) {
+			foundry.utils.mergeObject(converted, {
+				template: {
+					"size": conversion.converter(target.template.size),
+					"height": conversion.converter(target.template.height),
+					"width": conversion.converter(target.template.width),
+					"units": conversion.units
+				},
+				affects: {
+					"count": conversion.converter(target.affects.count)
+				}
+			});
+		}
+
+		Converters.applyScalarOrObjectTranslation(converted, "affects.special", translation);
+		return Object.keys(converted).length ? converted : undefined;
 	}
 
 	static senses(senses) {
@@ -196,33 +204,49 @@ export class Converters {
 		});
 	}
 
-	static rangeActivities(activities) {
-		Object.keys(activities).forEach(key => {
-			if (activities[key].range) Converters.range(activities[key].range);
-			if (activities[key].target) Converters.target(activities[key].target);
-		});
-
-		return activities;
+	static applyScalarOrObjectTranslation(target, fallbackPath, translation) {
+		if (typeof translation === "undefined" || translation === null) return;
+		if (Converters.isPlainObject(translation)) {
+			foundry.utils.mergeObject(target, translation);
+			return;
+		}
+		foundry.utils.setProperty(target, fallbackPath, translation);
 	}
 
-	static distanceAdvancement(advancements) {
-		Object.keys(advancements).forEach(key => {
-			const adv = advancements[key];
-			if (adv.type === "ScaleValue" && adv.configuration.type === "distance") {
-	            const conversion = Converters.conversionInfo[adv.configuration.distance.units || "ft"];
-				if (conversion) {
-					foundry.utils.mergeObject(adv.configuration.distance, { "units": conversion.units });
+	static isPlainObject(value) {
+		return !!value && typeof value === "object" && !Array.isArray(value);
+	}
 
-					Object.keys(adv.configuration.scale).forEach(key => {
-						foundry.utils.mergeObject(adv.configuration.scale[key], {
-							"value": conversion.converter(adv.configuration.scale[key].value)
-						});
-					});
-				}
-			}
-		});
+	static advancementIdentifier() {
+		return (identifier, _translation, advancement) => {
+			if (identifier?.length > 0) return identifier;
+			return advancement?.title?.slugify();
+		};
+	}
 
-		return advancements;
+	static advancementDistance() {
+		return (distance, _translation, advancement) => {
+			if (!convertMetricLength()) return undefined;
+			if (advancement?.type !== "ScaleValue" || advancement?.configuration?.type !== "distance") return undefined;
+
+			const conversion = Converters.conversionInfo[distance.units || "ft"];
+			return conversion ? { "units": conversion.units } : undefined;
+		};
+	}
+
+	static advancementScaleDistance() {
+		return (scale, _translation, advancement) => {
+			if (!convertMetricLength()) return undefined;
+			if (advancement?.type !== "ScaleValue" || advancement?.configuration?.type !== "distance") return undefined;
+
+			const conversion = Converters.conversionInfo[advancement.configuration.distance?.units || "ft"];
+			if (!conversion) return undefined;
+
+			return Object.entries(scale).reduce((converted, [key, value]) => {
+				converted[key] = { "value": conversion.converter(value.value) };
+				return converted;
+			}, {});
+		};
 	}
 
 	static tokenLight(light) {
@@ -272,269 +296,37 @@ export class Converters {
 		return parseInt(lb) / 2;
 	}
 
-	// Override babele pages converters
-	static pages() {
-		return (pages, translations, data) => Converters._pages(pages, translations, data);
-	}
+	static effectDistanceChange() {
+		return (value, translation, change) => {
+			if (change?.mode == 1) return translation;
 
-	static _pages(pages, translations, data) {
-		pages.map(data => {
-			if (!translations) {
-				return data;
+			const translated = String(translation ?? "");
+			if (translated.startsWith("+") || translated.startsWith("-")) {
+				return `${translated[0]}${Converters.footsToMeters(translated.substring(1))}`;
 			}
 
-			const translation = translations[data._id] || translations[data.name];
-			if (!translation) {
-				console.warn(`Missing translation : ${data._id} ${data.name}`);
-				return data;
+			return Converters.footsToMeters(translated);
+		};
+	}
+
+	static effectRangeChange() {
+		return (value, translation, change) => {
+			if (change?.mode == 1) return translation;
+
+			const translated = String(translation ?? "");
+			if (parseInt(translated)) {
+				return Converters.footsToMeters(translated);
 			}
 
-			return foundry.utils.mergeObject(data, {
-				name: translation.name ?? data.name,
-				image: { caption: translation.caption ?? data.image.caption },
-				src: translation.src ?? data.src,
-				text: { content: translation.text ?? data.text.content },
-				video: {
-					width: translation.width ?? data.video.width,
-					height: translation.height ?? data.video.height,
-				},
-				system: {
-					tooltip: translation.tooltip ?? data.system.tooltip,
-					subclassHeader: translation.subclassHeader ?? data.system.subclassHeader,
-					unlinkedSpells: data.system.unlinkedSpells ? Converters.unlinkedSpells(data.system.unlinkedSpells, translation.unlinkedSpells) : data.system.unlinkedSpells,
-					description: {
-						value: translation.description ?? data.system.description?.value,
-						additionalEquipment: translation.additionalEquipment ?? data.system.description?.additionalEquipment,
-						additionalHitPoints: translation.additionalHitPoints ?? data.system.description?.additionalHitPoints,
-						additionalTraits: translation.additionalTraits ?? data.system.description?.additionalTraits,
-						subclass: translation.subclass ?? data.system.description?.subclass
-					}
-				},
-				flags: { dnd5e: { title: translation.flagsTitle ?? data.flags.dnd5e?.title } },
-				translated: true,
-			});
-		});
+			const match = translated.match(/^(.+?)\s*(\d+)(?:\s+(.*))?$/);
+			if (!match) return translation;
 
-		return Converters.sortPages(pages, journalPagesToSort[data._id]);
-	}
-
-	static unlinkedSpells(unlinkedSpells, translations) {
-		if (!translations) return unlinkedSpells;
-
-		if (Array.isArray(unlinkedSpells)) {
-			return unlinkedSpells.map(spell => {
-				const translation = translations[spell.name];
-				if (translation) {
-					return foundry.utils.mergeObject(spell, { name: translation.name ?? spell.name });
-				}
-				return profile;
-			});
-		}
-
-		return unlinkedSpells;
-	}
-
-	static sortPages(pages, journal) {
-		if (!journal) return pages;
-
-		const normalizeName = name =>
-			name
-				.toLowerCase()
-				.replace(/^(l')/i, "")
-				.replace(/^(la|les|le|une|un|des)\s+/i, "")
-				.replace(/\b(d'|de la|de l'|des|de|du)\b\s*/gi, "")
-				.trim();
-
-		if (journal.length || Object.keys(journal).length) {
-			if (Array.isArray(journal)) {
-				const sortedPages = journal.map(id => pages.find(p => p._id === id)).filter(Boolean);
-				const remainingPages = pages.filter(p => !journal.includes(p._id));
-				pages = [...sortedPages, ...remainingPages];
-			} else {
-				const firstPagesIds = Array.isArray(journal.firstPages) ? journal.firstPages : [];
-				const firstPages = firstPagesIds.map(id => pages.find(p => p._id === id)).filter(Boolean);
-
-				if (journal.conserveOriginalSort) {
-					pages.sort((a, b) => a.sort - b.sort);
-				} else {
-					pages = pages
-						.filter(p => !firstPagesIds.includes(p._id))
-						.sort((a, b) => {
-							const nameA = journal.includeArticle ? a.name : normalizeName(a.name);
-							const nameB = journal.includeArticle ? b.name : normalizeName(b.name);
-							return nameA.localeCompare(nameB);
-						});;
-				}
-
-				let otherPages = [];
-				if (journal.pagesGroups?.length) {
-					let workingPages = [...pages];
-					for (const group of journal.pagesGroups) {
-						const parentIndex = workingPages.findIndex(p => p._id === group.parent);
-						if (parentIndex === -1 || !group.associatePages?.length) continue;
-
-						let groupIds = [...group.associatePages];
-
-						if (group.isRange && group.associatePages.length === 2) {
-							const [startId, endId] = group.associatePages;
-							const startIndex = workingPages.findIndex(p => p._id === startId);
-							const endIndex = workingPages.findIndex(p => p._id === endId);
-							if (startIndex !== -1 && endIndex !== -1) {
-								const [from, to] = startIndex <= endIndex ? [startIndex, endIndex] : [endIndex, startIndex];
-								groupIds = workingPages.slice(from, to + 1).map(p => p._id);
-							}
-						}
-
-						const before = workingPages
-							.slice(0, parentIndex + 1)
-							.filter(p => !firstPagesIds.includes(p._id) && !groupIds.includes(p._id));
-
-						const sortedGroup = groupIds.map(id => workingPages.find(p => p._id === id)).filter(Boolean);
-
-						if (group.isRange) {
-							sortedGroup.sort((a, b) => {
-								const nameA = group.includeArticle ? a.name : normalizeName(a.name);
-								const nameB = group.includeArticle ? b.name : normalizeName(b.name);
-								return nameA.localeCompare(nameB);
-							});
-						}
-
-						const after = workingPages
-							.slice(parentIndex + 1)
-							.filter(p => !firstPagesIds.includes(p._id) && !groupIds.includes(p._id));
-
-						workingPages = [...before, ...sortedGroup, ...after];
-					}
-					otherPages = workingPages;
-				} else {
-					otherPages = pages;
-				}
-
-				pages = [...firstPages, ...otherPages];
-			}
-		} else {
-			pages.sort((a, b) => normalizeName(a.name).localeCompare(normalizeName(b.name)));
-		}
-
-		return pages.forEach((page, index) => page.sort = (index + 1) * 1000);
-	}
-
-	static tokens() {
-        return (tokens, translations, data, tc) => Converters._tokens(tokens, translations, data, tc);
-    }
-
-    static _tokens(tokens, translations, data, tc) {
-        tokens.map(token => {
-            return foundry.utils.mergeObject(token, {
-                light: Converters.tokenLight(token.light),
-                sight: { range: Converters.footsToMeters(token.sight.range) }
-            });
-        });
-
-        if (!translations) return tokens;
-
-        return tokens.map(token => {
-            const translation = translations[token._id] || translations[token.name];
-            if (!translation) return token;
-
-            const delta = token.delta;
-            const actorConverter = babeleConverters.fromDefaultMapping("Actor", "actors");
-            const deltaTranslated = delta ? actorConverter([delta], { [delta._id]: translation }, data, tc)[0] : delta;
-            if (!deltaTranslated.name) deltaTranslated.name = translation.name ?? delta.name;
-            return foundry.utils.mergeObject(token, {
-                name: translation.name ?? token.name,
-                delta: deltaTranslated
-            });
-        });
-    }
-
-	static effects() {
-		return (data, translations) => Converters._effects(data, translations);
-	}
-
-	static _effects(data, translations) {
-		if (!translations) {
-			return data;
-		}
-		if (typeof data !== 'object') {
-			return translations;
-		}
-
-		if (Array.isArray(data)) {
-			return data.map(effect => {
-				const translation = translations[effect._id] || translations[effect.name];
-				if (translation) {
-					return foundry.utils.mergeObject(effect, {
-						name: translation.name ?? effect.name,
-						description: translation.description ?? effect.description,
-						changes: effect.changes ? Converters.effectsChanges(effect.changes, translation.changes) : effect.changes
-					});
-				}
-				return effect;
-			});
-		}
-
-		return data;
-	}
-
-	static effectsChanges(changes, translations) {
-		const movementSensesType = [
-			"system.attributes.movement.burrow",
-			"system.attributes.movement.climb",
-			"system.attributes.movement.fly",
-			"system.attributes.movement.swim",
-			"system.attributes.movement.walk",
-			"system.attributes.senses.ranges.blindsight",
-			"system.attributes.senses.ranges.darkvision",
-			"system.attributes.senses.ranges.tremorsense",
-			"system.attributes.senses.ranges.truesight",
-			"system.attributes.senses.blindsight", //Avant 5.3.0, à supprimer plus tard
-			"system.attributes.senses.darkvision", //Avant 5.3.0, à supprimer plus tard
-			"system.attributes.senses.tremorsense", //Avant 5.3.0, à supprimer plus tard
-			"system.attributes.senses.truesight" //Avant 5.3.0, à supprimer plus tard
-		];
-
-		changes.forEach(change => {
-			if (change.mode != 1) {
-				const value = String(change.value ?? "");
-				if (movementSensesType.includes(change.key)) {
-					if (value.startsWith("+") || value.startsWith("-")) {
-						change.value = `${value[0]}${Converters.footsToMeters(value.substring(1))}`;
-					} else {
-						change.value = Converters.footsToMeters(value);
-					}
-				}
-				if (["system.range.value", "system.range.long"].includes(change.key)) {
-					if (parseInt(value)) {
-						change.value = Converters.footsToMeters(value);
-					} else {
-						const match = value.match(/^(.+?)\s*(\d+)(?:\s+(.*))?$/);
-						if (match) {
-							let [_, begin, numberStr, end] = match;
-							begin ??= "";
-							const convertedNumber = Converters.footsToMeters(numberStr);
-							end ??= "";
-							change.value = `${begin} ${convertedNumber} ${end}`;
-						}
-					}
-				}
-			}
-			return change;
-		});
-
-		if (!translations) return changes;
-
-		if (Array.isArray(changes)) {
-			return changes.map(change => {
-				const translation = translations[change.key];
-				if (translation) {
-					return foundry.utils.mergeObject(change, { value: translation ?? change.value });
-				}
-				return change;
-			});
-		}
-
-		return changes;
+			let [_, begin, numberStr, end] = match;
+			begin ??= "";
+			end ??= "";
+			const convertedNumber = Converters.footsToMeters(numberStr);
+			return `${begin} ${convertedNumber} ${end}`;
+		};
 	}
 
 	static alignment() {
@@ -579,73 +371,6 @@ export class Converters {
 		return translated || alignment;
 	}
 
-	static activities() {
-		return (activities, translations) => Converters._activities(activities, translations);
-	}
-
-	static _activities(activities, translations) {
-		if (!translations) return activities;
-
-		Object.keys(activities).forEach(key => {
-			const activity = activities[key];
-			const translationKey = activity.name?.length ? activity.name : activity.type;
-			const translation = translations[activity._id] || translations[translationKey];
-			if (translation) {
-				foundry.utils.mergeObject(activity, {
-					name: translation.name ?? activity.name,
-					activation: { condition: translation.condition ?? activity.activation?.condition },
-					description: { chatFlavor: translation.chatFlavor ?? activity.description?.chatFlavor },
-					duration: { special: translation.duration ?? activity.duration?.special },
-					range: { special: translation.range ?? activity.range?.special },
-					target: { affects: { special: translation.target ?? activity.target?.affects?.special } },
-					profiles: activity.profiles ? Converters.summonProfiles(activity.profiles, translation.profiles) : activity.profiles
-				});
-			}
-		});
-
-		return activities;
-	}
-
-	static summonProfiles(profiles, translations) {
-		if (!translations) return profiles;
-
-		if (Array.isArray(profiles)) {
-			return profiles.map(profile => {
-				const translation = translations[profile.name];
-				if (translation) {
-					return foundry.utils.mergeObject(profile, { name: translation.name ?? profile.name });
-				}
-				return profile;
-			});
-		}
-
-		return profiles;
-	}
-
-	static advancement() {
-		return (advancements, translations) => Converters._advancement(advancements, translations);
-	}
-
-	static _advancement(advancements, translations) {
-		if (!translations) return advancements;
-
-		Object.keys(advancements).forEach(key => {
-			const adv = advancements[key];
-			const translation = translations[adv._id] || translations[adv.title];
-			if (translation) {
-				foundry.utils.mergeObject(adv, {
-					title: translation.title ?? adv.title,
-					hint: translation.hint ?? adv.hint,
-					configuration: {
-						identifier: adv.configuration.identifier?.length > 0 ? adv.configuration.identifier : adv.title?.slugify()
-					}
-				});
-			}
-		});
-
-		return advancements;
-	}
-
 	static planarSubtype() {
 		return (habitat, translation) => Converters._planarSubtype(habitat, translation);
 	}
@@ -658,85 +383,3 @@ export class Converters {
 		});
 	}
 }
-
-export var journalPagesToSort = {
-	//SRD 5.1
-	//Chapter 3: Classes
-	"gqecphEUnz4ktrQ9": {
-		firstPages: ["8jxEuy0PV2HNySQC"]
-	},
-	//Chapter 10: Spellcasting
-	"QvPDSUsAiEn3hD8s": {
-		firstPages: ["FX9TS9vmt4dyOoqJ", "evx9TWix4wYU51a5", "wre9ECSVuEyJBYhr"]
-	},
-	//Appendix A: Conditions
-	"w7eitkpD7QQTB6j0": {
-		firstPages: ["ZOCWbO9IYvBf9WyR"]
-	},
-	//Appendix D: Senses and Speeds
-	"eVtpEGXjA2tamEIJ": [
-		"8AIlZ95v54mL531X", "I6ABWHBYwGl55dLY", "0RBamBThjzeAdMSt", "8iC24otVX4n1yrYw",
-		"eW0LypO5xZZdq4I9", "I13SYX1zaCLYmaYF", "EQWAcrLYsd96MzJH", "X2CTP455Zpr7Shs9"
-	],
-	//SRD 5.2
-	//Character Species
-	"phbSpeciesDescri": {
-		firstPages: ["7iLsgz6RUQJVpUsH"]
-	},
-	//Spells
-	"phbSpells0000000": {
-		conserveOriginalSort: true,
-		pagesGroups: [
-			{
-				parent: "yspaGdvukcwiodvl",
-				isRange: true,
-				associatePages: ["wwia6Wwo4BgE9GSI", "6AnqLUowgdsqMFvz"]
-			}
-		]
-	},
-	//Rules Glossary
-	"phbAppendixCRule": {
-		firstPages: ["FvDonO0qOQWp1RIw"],
-		pagesGroups: [
-			{
-				parent: "SsIXfzS2ZttwAaKj",
-				associatePages: [
-					"f4fZHwBvpbpzRyn4", "w1AGsemFERfjqWNx", "3YJIuyCMmuUrfmuX", "Nuz0Wx4a4aAPcC34",
-					"rqhOsUY4wWa1oHTy", "4V59Q1dlWjNhpJGo", "nI9tN6Oq7fCV7hcA", "iIIDUsmSOkL0xNzF",
-					"ySj4gYZ4ADZoia7R", "6l6nBKip4LqB1sCU", "5S8i59qskkd9GGcJ", "UDlogfdiT2uYEZz4"
-				]
-			},
-			{
-				parent: "ahMxQJTGDhq08GWQ",
-				associatePages: [
-					"RVcWSqblHIs7SUzn", "BNxLbtJofbNGzjsp", "eYX5eimGuYhHPoj4"
-				]
-			},
-			{
-				parent: "5hyEitPd1Kb27fP5",
-				associatePages: [
-					"gAvV8TLyS8UGq00x", "lCwPWK4ODxw2IV1x", "FZFvLNOX0lHaHZ1k", "mPBGM1vguT5IPzxT", "earBo4vQPC1ti4g7"
-				]
-			},
-			{
-				parent: "UIKLZmiLuENHk1wn",
-				associatePages: [
-					"QxCrRcgMdUd3gfzz", "KbQ1k0OIowtZeQgp", "qlRw66tJhk0zLnwq", "uDogReMO6QtH6NDw", "vLAsIUa0FhZNsyLk",
-					"93uaingTESo8N1qL", "HWs8kEojffqwTSJz", "dqLeGdpHtb8FfcxX", "jSQtPgNm0i4f3Qi3", "EjbXjvyQAMlDyANI",
-					"fZCRaKEJd4KoQCqH", "MQIZ1zRLWRcNOtPN", "4i3G895hy99piand", "RnxZoTglPnLc6UPb", "6vtLuQT9lwZ9N299"
-				]
-			},
-			{
-				parent: "On6Sg3vUokAkXBB5",
-				associatePages: [
-					"JwK8XOkGSX9xE5Dc", "p5qUBMQO7shfNeCD", "i3ijpxEn5LuSO7C0",
-					"eSsITWhcNMkoa9WP", "T1ln1l6uKkkMuieP", "LgpZdAOhTnSHGCNa"
-				]
-			}
-		]
-	},
-	//Monsters A to Z
-	"mmMonstersAtoZ00": {},
-	//Animals
-	"mmAppendixAAnima": {}
-};

--- a/compendium_fr/dnd5e.rules.json
+++ b/compendium_fr/dnd5e.rules.json
@@ -30,6 +30,18 @@
     "Appendix D: Senses and Speeds": {
       "name": "Annexe D : Sens et vitesses",
       "pages": {
+        "$sort": {
+          "order": [
+            "8AIlZ95v54mL531X",
+            "I6ABWHBYwGl55dLY",
+            "0RBamBThjzeAdMSt",
+            "8iC24otVX4n1yrYw",
+            "eW0LypO5xZZdq4I9",
+            "I13SYX1zaCLYmaYF",
+            "EQWAcrLYsd96MzJH",
+            "X2CTP455Zpr7Shs9"
+          ]
+        },
         "Blindsight": {
           "text": "<p>Une créature dotée de la vision aveugle perçoit l’environnement sans recourir à la vue, dans un rayon donné.</p>\n<p>Les créatures dépourvues d’yeux, comme les torves ou les vases grises, et les créatures dotées de l’écholocalisation ou de sens accrus, comme les chauves-souris et les dragons véritables, disposent de ce sens.</p>\n<p>Quand un monstre est naturellement aveugle, une note l’indique entre parenthèses, ce qui signifie que le rayon de sa vision aveugle détermine la portée de sa perception.</p>",
           "name": "Vision aveugle"
@@ -76,6 +88,18 @@
     "Chapter 10: Spellcasting": {
       "name": "Chapitre 10 : Sorts",
       "pages": {
+        "$sort": {
+          "by": "name",
+          "locale": "fr",
+          "first": [
+            "FX9TS9vmt4dyOoqJ",
+            "evx9TWix4wYU51a5",
+            "wre9ECSVuEyJBYhr"
+          ],
+          "ignoreLeadingWords": ["le", "la", "les", "un", "une", "des"],
+          "ignoreLeadingPrefixes": ["l'", "d'"],
+          "ignoreWords": ["d'", "de la", "de l'", "des", "de", "du"]
+        },
         "Spellcasting": {
           "name": "Sorts",
           "text": "<p>La magie, omniprésente dans les mondes imaginaires, se manifeste le plus souvent sous la forme de sorts.</p><p>Cette section fournit les règles concernant l'incantation de sorts. Les classes de personnage apprennent et préparent leurs sorts de plusieurs manières, et les monstres les utilisent aussi à leur façon. Quelle que soit sa source, un sort obéit aux règles qui suivent.</p>"
@@ -159,6 +183,14 @@
     "Chapter 3: Classes": {
       "name": "Chapitre 3 : Classes",
       "pages": {
+        "$sort": {
+          "by": "name",
+          "locale": "fr",
+          "first": ["8jxEuy0PV2HNySQC"],
+          "ignoreLeadingWords": ["le", "la", "les", "un", "une", "des"],
+          "ignoreLeadingPrefixes": ["l'", "d'"],
+          "ignoreWords": ["d'", "de la", "de l'", "des", "de", "du"]
+        },
         "Overview": {
           "name": "Résumé",
           "text": "<table><caption>Résumé des classes</caption><thead><tr><th>Classe</th><th>Dés de vie</th><th>Caractéristique principale</th><th>Maîtrise des jets de sauvegarde</th><th>Maîtrise des armures et armes</th></tr></thead><tbody><tr><td>@UUID[Compendium.dnd5e.classes.Item.pvEzGSv71zBhaolc]{Barbare}</td><td>d12</td><td>Force</td><td>Force et Constitution</td><td>Armures légères et intermédiaires, boucliers, armes courantes et de guerre</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.ILvRZGEx3aXqSVUt]{Barde}</td><td>d8</td><td>Charisme</td><td>Dextérité et Charisme</td><td>Armures légères, armes courantes, arbalète de poing, épée courte, épée longue, rapière</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.tlwBnN8GmqJcTgub]{Clerc}</td><td>d8</td><td>Sagesse</td><td>Sagesse et Charisme</td><td>Armures légères et intermédiaires, boucliers, armes courantes</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.ygVYgPbJkaH0tH1N]{Druide}</td><td>d8</td><td>Sagesse</td><td>Intelligence et Sagesse</td><td>Armures légères et intermédiaires (sans métal), boucliers (sans métal), bâton de combat, cimeterre, dague, faucille, fléchettes, fronde, gourdin, javeline, lance, masse d'armes</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.6T08zzKtmmpVwlXU]{Ensorceleur}</td><td>d6</td><td>Charisme</td><td>Constitution et Charisme</td><td>Arbalète légère, bâton de combat, dague, fléchettes, fronde</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.ABEBgWyRhVlDUIfq]{Guerrier}</td><td>d10</td><td>Force ou Dextérité</td><td>Force et Constitution</td><td>Toutes les armures, bouclier, armes courantes et de guerre</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.wZK2Q0rXB0AQo8h3]{Magicien}</td><td>d6</td><td>Intelligence</td><td>Intelligence et Sagesse</td><td>Arbalète légère, bâton de combat, dague, fléchettes, fronde</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.6VoZrWxhOEKGYhnq]{Moine}</td><td>d8</td><td>Dextérité et Sagesse</td><td>Force et Dextérité</td><td>Armes courantes, épée courte</td></tr><tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.7WJp9vhi6F6SlAFa]{Occultiste}</td><td>d8</td><td>Charisme</td><td>Sagesse et Charisme</td><td>Armures légères, armes courantes</td></tr><td>@UUID[Compendium.dnd5e.classes.Item.gZiUvbXWLs0pOp0c]{Paladin}</td><td>d10</td><td>Force et Charisme</td><td>Sagesse et Charisme</td><td>Toutes les armures, boucliers, armes courantes et de guerre</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.VkRQ7glQvTWWiOCS]{Rôdeur}</td><td>d10</td><td>Dextérité et Sagesse</td><td>Force et Dextérité</td><td>Armures légères et intermédiaires, boucliers, armes courantes et de guerre</td></tr><tr><td>@UUID[Compendium.dnd5e.classes.Item.xEb8jmA5HlNs7xTF]{Roublard}</td><td>d8</td><td>Dextérité</td><td>Dextérité et Intelligence</td><td>Armures légères, armes courantes, arbalète de poing, épée courte, épée longue, rapière</td></tr></tbody></table>"
@@ -499,6 +531,14 @@
     "Appendix A: Conditions": {
       "name": "Annexe A : États",
       "pages": {
+        "$sort": {
+          "by": "name",
+          "locale": "fr",
+          "first": ["ZOCWbO9IYvBf9WyR"],
+          "ignoreLeadingWords": ["le", "la", "les", "un", "une", "des"],
+          "ignoreLeadingPrefixes": ["l'", "d'"],
+          "ignoreWords": ["d'", "de la", "de l'", "des", "de", "du"]
+        },
         "Conditions": {
           "name": "États",
           "text": "<p>Les états spéciaux (ou simplement « états ») influent sur les capacités d'une créature de diverses façons. Ils peuvent résulter d'un sort, d'une aptitude de classe, d'une attaque de monstre ou d'un autre effet. La plupart, comme l'état aveuglé, défavorisent le sujet, mais certains, comme l'état invisible, sont plutôt bénéfiques.</p><p>Un état persiste jusqu'à ce qu'on y mette fin (comme en se relevant pour l'état à terre) ou jusqu'à ce qu’on arrive au terme de la durée indiquée par l'effet qui a imposé l'état.</p><p>Si plusieurs effets imposent le même état à une créature donnée, chaque application de l'état a sa propre durée mais les effets de l'état n'empirent pas pour autant. L'état affecte la créature ou il ne l'affecte pas.</p><p>Les définitions suivantes indiquent ce qu'il advient d'une créature soumise à un état donné.</p>"

--- a/compendium_fr/mappings.json
+++ b/compendium_fr/mappings.json
@@ -22,10 +22,6 @@
       "path": "system.attributes.movement",
       "converter": "movement"
     },
-    "items": {
-      "path": "items",
-      "converter": "items"
-    },
     "senses": {
       "path": "system.attributes.senses",
       "converter": "senses"
@@ -33,10 +29,6 @@
     "communication": {
       "path": "system.traits.languages.communication",
       "converter": "communication"
-    },
-    "effects": {
-      "path": "effects",
-      "converter": "effects"
     },
     "tokenLight": {
       "path": "prototypeToken.light",
@@ -55,6 +47,57 @@
       "converter": "planarSubtype"
     }
   },
+  "ActiveEffect": {
+    "changes": {
+      "path": "changes",
+      "converter": "structured",
+      "cardinality": "many",
+      "container": "array",
+      "key": "key",
+      "valuePath": "value",
+      "mapping": {
+        "_variants": [
+          {
+            "_when": {
+              "path": "key",
+              "in": [
+                "system.attributes.movement.burrow",
+                "system.attributes.movement.climb",
+                "system.attributes.movement.fly",
+                "system.attributes.movement.swim",
+                "system.attributes.movement.walk",
+                "system.attributes.senses.ranges.blindsight",
+                "system.attributes.senses.ranges.darkvision",
+                "system.attributes.senses.ranges.tremorsense",
+                "system.attributes.senses.ranges.truesight",
+                "system.attributes.senses.blindsight",
+                "system.attributes.senses.darkvision",
+                "system.attributes.senses.tremorsense",
+                "system.attributes.senses.truesight"
+              ]
+            },
+            "value": {
+              "path": "value",
+              "converter": "effectDistanceChange"
+            }
+          },
+          {
+            "_when": {
+              "path": "key",
+              "in": [
+                "system.range.value",
+                "system.range.long"
+              ]
+            },
+            "value": {
+              "path": "value",
+              "converter": "effectRangeChange"
+            }
+          }
+        ]
+      }
+    }
+  },
   "Item": {
     "subtype": "system.type.subtype",
     "requirements": "system.requirements",
@@ -71,23 +114,38 @@
     },
     "advancement": {
       "path": "system.advancement",
-      "converter": "advancement"
-    },
-    "distanceAdvancement": {
-      "path": "system.advancement",
-      "converter": "distanceAdvancement"
-    },
-    "effects": {
-      "path": "effects",
-      "converter": "effects"
+      "converter": "structured",
+      "cardinality": "many",
+      "container": "keyed",
+      "keys": ["_id", "title"],
+      "mapping": {
+        "title": "title",
+        "hint": "hint",
+        "identifier": {
+          "path": "configuration.identifier",
+          "converter": "advancementIdentifier"
+        },
+        "_variants": [
+          {
+            "_when": {
+              "path": "type",
+              "equals": "ScaleValue"
+            },
+            "distance": {
+              "path": "configuration.distance",
+              "converter": "advancementDistance"
+            },
+            "scale": {
+              "path": "configuration.scale",
+              "converter": "advancementScaleDistance"
+            }
+          }
+        ]
+      }
     },
     "weight": {
       "path": "system.weight",
       "converter": "weight"
-    },
-    "rangeActivities": {
-      "path": "system.activities",
-      "converter": "rangeActivities"
     },
     "range": {
       "path": "system.range",
@@ -99,7 +157,57 @@
     },
     "activities": {
       "path": "system.activities",
-      "converter": "activities"
+      "converter": "structured",
+      "cardinality": "many",
+      "container": "keyed",
+      "keys": ["_id", "name"],
+      "mapping": {
+        "name": "name",
+        "condition": "activation.condition",
+        "chatFlavor": "description.chatFlavor",
+        "duration": "duration.special",
+        "range": {
+          "path": "range",
+          "converter": "range"
+        },
+        "target": {
+          "path": "target",
+          "converter": "target"
+        },
+        "_variants": [
+          {
+            "_when": {
+              "path": "type",
+              "equals": "utility"
+            },
+            "roll": "roll.name"
+          },
+          {
+            "_when": {
+              "any": [
+                {
+                  "path": "type",
+                  "equals": "summon"
+                },
+                {
+                  "path": "type",
+                  "equals": "transform"
+                }
+              ]
+            },
+            "profiles": {
+              "path": "profiles",
+              "converter": "structured",
+              "cardinality": "many",
+              "container": "array",
+              "key": "name",
+              "mapping": {
+                "name": "name"
+              }
+            }
+          }
+        ]
+      }
     },
     "senses": {
       "path": "system.senses",
@@ -116,5 +224,25 @@
   },
   "JournalEntry": {
     "flagsTitle": "flags.dnd5e.title"
+  },
+  "JournalEntryPage": {
+    "tooltip": "system.tooltip",
+    "subclassHeader": "system.subclassHeader",
+    "description": "system.description.value",
+    "additionalEquipment": "system.description.additionalEquipment",
+    "additionalHitPoints": "system.description.additionalHitPoints",
+    "additionalTraits": "system.description.additionalTraits",
+    "subclass": "system.description.subclass",
+    "flagsTitle": "flags.dnd5e.title",
+    "unlinkedSpells": {
+      "path": "system.unlinkedSpells",
+      "converter": "structured",
+      "cardinality": "many",
+      "container": "array",
+      "key": "name",
+      "mapping": {
+        "name": "name"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

This pull request updates the French D&D5e translation module to align it with the new Babele `2.9.x` mapping and converter features.

The main goal is to reduce custom translation logic where Babele core now provides equivalent generic behavior, keeping custom code only where it is still language-specific or D&D-specific.

## Main Changes

### Migrated generic embedded document handling to Babele core converters

Several custom converters and mapping overrides have been removed or simplified because they are now covered by Babele’s built-in `document` and `structured` converters.

This includes generic embedded document structures such as:

- Actor embedded items
- Actor embedded effects
- Item embedded effects
- JournalEntry pages, where applicable
- ActiveEffect changes, where the new `valuePath` support can be used

### Reworked structured mappings

Mappings using structured data now rely on the newer Babele features:

- `container`
- `cardinality`
- `keys`
- `valuePath`
- `_variants`

This makes the mappings more declarative and avoids custom converters for cases that can now be expressed directly in mapping configuration.

### ActiveEffect changes migration

The previous custom handling for `ActiveEffect.changes` has been reduced by using Babele’s structured converter with `valuePath`.

Where system-specific value conversion is still required, the mapping now delegates only the narrow conversion logic to custom converters instead of replacing the whole `changes` handling.

### D&D-specific mappings retained

Custom logic remains where the structure is specific to the D&D5e system, for example:

- Item activities
- Item advancement
- D&D-specific metric conversions
- Field conversions that depend on D&D5e data semantics

The intent is to avoid moving D&D-specific behavior into Babele core while still benefiting from the generic core improvements.

### Journal page ordering

JournalEntry page ordering has been updated to use Babele’s new document collection sorting support.

The sort configuration is kept in the translation module instead of being added to Babele defaults, because alphabetical or language-specific ordering is not necessarily correct for every system or language.

### Hook and registration cleanup

The module registration has been updated to the current Babele initialization style:
```js
Hooks.once("babele.init", (babele) => {
  babele.register({
    module: "dnd5e_fr-FR",
    lang: "fr",
    dir: "compendium_fr"
  });
});
```
This keeps the module aligned with the current Babele public API.

###  Rationale
Babele 2.9.x introduced a more expressive mapping engine. Many behaviors that previously required custom converters in this module can now be represented declaratively.
This pull request therefore reduces maintenance cost, improves compatibility with future Babele versions, and makes the French translation module easier to reason about.
Custom code has not been removed blindly: logic that is still genuinely D&D-specific or French-translation-specific has been preserved.